### PR TITLE
yc add table for wafer location

### DIFF
--- a/Documentation/DB/DBTables/SVT_DB_Tables_SourceOfTruth.txt
+++ b/Documentation/DB/DBTables/SVT_DB_Tables_SourceOfTruth.txt
@@ -17,6 +17,13 @@ Table Wafer {
   waferTypeId integer [ref: > WaferType.id]
 }
 
+Table WaferLocation {
+  waferid integer [ref: > Wafer.id, not null]
+  generalLocation wpGeneralLocation
+  creationTime timestamp [default: `CURRENT_TIMESTAMP`]
+  description string
+}
+
 Table Version {
   id integer [primary key]
   name string


### PR DESCRIPTION
This PR add a table for wafer location, location is selected from the wpGeneralLocation.
